### PR TITLE
only process Terms in the MONDO namespace (not CHEBI, etc.)

### DIFF
--- a/app/Console/Commands/Mondo/UpdateMondoData.php
+++ b/app/Console/Commands/Mondo/UpdateMondoData.php
@@ -58,7 +58,9 @@ class UpdateMondoData extends Command
         $parser->setOboPath($tmpFilePath);
         
         while ($term = $parser->getNextTerm()) {
-            Disease::updateOrCreate(['mondo_id' => $term['mondo_id']], $term);
+            if (str_starts_with($term['mondo_id'], 'MONDO:')) {
+                Disease::updateOrCreate(['mondo_id' => $term['mondo_id']], $term);
+            }
         }
 
         $lastMondoUpdate = AppState::findByName('last_mondo_update');


### PR DESCRIPTION
Something changed in what gets included in the release mondo.obo file-- with most recent version, we start to get `Term`s included from CHEBI. It may be that we could use a different file (maybe `mondo-base.obo`?), but this just restricts processing to terms that have a MONDO: prefix/namespace.

fixes GT-44