### PR TITLE
Select phenotypes by id in curation edit

### DIFF
--- a/app/Http/Controllers/Api/CurationController.php
+++ b/app/Http/Controllers/Api/CurationController.php
@@ -149,19 +149,14 @@ class CurationController extends Controller
     private function setPhenotypes(Curation $curation, $request)
     {
         if ($request->phenotypes) {
-            $phenotypes_mim_numbers = collect($request->phenotypes)->map(fn($ph_hash) => $ph_hash['mim_number']);
-            SyncPhenotypes::dispatchSync($curation, $phenotypes_mim_numbers);
+            $phenotypeIds = array_map(fn($el) => $el['id'], $request->phenotypes);
+            SyncPhenotypes::dispatchSync($curation, $phenotypeIds);
         }
 
         if ($request->isolated_phenotype) {
             // $pheno = $this->omim->getEntry($request->isolated_phenotype);
             $pheno = Phenotype::findByMimNumber($request->isolated_phenotype);
-            SyncPhenotypes::dispatchSync($curation, [
-                [
-                    'mim_number' => $pheno->mimNumber,
-                    'name' => $pheno->title
-                ],
-            ]);
+            SyncPhenotypes::dispatchSync($curation, [$pheno->id]);
         }
     }
 

--- a/app/Http/Controllers/Api/OmimController.php
+++ b/app/Http/Controllers/Api/OmimController.php
@@ -86,6 +86,7 @@ class OmimController extends Controller
     private function serializePhenotypeModelForResponse($phenotype):array
     {
         return [
+            'id' => $phenotype->id,
             'phenotype' => $phenotype->name,
             'phenotypeMimNumber' => $phenotype->mim_number,
             'phenotypeInheritance' => $phenotype->moi,

--- a/app/Http/Resources/PhenotypeResource.php
+++ b/app/Http/Resources/PhenotypeResource.php
@@ -16,7 +16,7 @@ class PhenotypeResource extends JsonResource
     public function toArray($request)
     {
         return [
-            // 'id' => $this->id,
+            'id' => $this->id,
             'mim_number' => $this->mim_number,
             'name' => $this->name,
             'curations' => CurationResource::collection($this->whenLoaded('curations'))

--- a/app/Jobs/Curations/SyncPhenotypes.php
+++ b/app/Jobs/Curations/SyncPhenotypes.php
@@ -14,13 +14,13 @@ class SyncPhenotypes implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public function __construct(private Curation $curation, private $mim_numbers)
+    public function __construct(private Curation $curation, private $phenotypeIds)
     {
     }
 
     public function handle()
     {
-        $phenotypes = Phenotype::whereIn('mim_number', $this->mim_numbers ?? []);
+        $phenotypes = Phenotype::whereIn('id', $this->phenotypeIds ?? []);
         if (!$phenotypes && $phenotypes->count() > 0) {
             return;
         }

--- a/resources/assets/js/components/Curations/Forms/Phenotypes.vue
+++ b/resources/assets/js/components/Curations/Forms/Phenotypes.vue
@@ -21,6 +21,7 @@
                             &nbsp;&nbsp;&nbsp;&nbsp;
                         </template>
                         <template v-slot:cell(checkbox)="data">
+                            <pre>{{ data.value }}</pre>
                             <input 
                                 class="form-check-input form-check-input-lg"
                                 type="checkbox" 
@@ -126,6 +127,7 @@
                         label: ' ',
                         formatter: (value, key, item) => {
                             return {
+                                'id': item.id,
                                 'mim_number': item.phenotypeMimNumber,
                                 'name': item.phenotype
                             }

--- a/resources/assets/js/components/Curations/Forms/Phenotypes.vue
+++ b/resources/assets/js/components/Curations/Forms/Phenotypes.vue
@@ -1,87 +1,3 @@
-<style></style>
-<template>
-    <div class="component-container">
-        <div>
-                <div class="alert alert-info" v-show="loading && phenotypes.length < 1">Loading phenotype information...</div>
-                <div  v-show="!loading || phenotypes.length > 0">
-                    <div class="alert alert-secondary clearfix" v-show="phenotypes.length == 0">
-                        <p>The gene <strong>{{ updatedCuration.value }}</strong> is not associated with a disease entity per OMIM at this time.</p>
-                    </div>
-
-                    <b-table 
-                         v-show="showTable"
-                        :items="phenotypes"
-                        :fields="fields"
-                        stacked="sm"
-                        striped 
-                        hover 
-                        small
-                    >
-                        <template v-slot:head(checkbox)="data">
-                            &nbsp;&nbsp;&nbsp;&nbsp;
-                        </template>
-                        <template v-slot:cell(checkbox)="data">
-                            <pre>{{ data.value }}</pre>
-                            <input 
-                                class="form-check-input form-check-input-lg"
-                                type="checkbox" 
-                                v-model="updatedCuration.phenotypes"
-                                :value="data.value"
-                                :disabled="disabled"
-                            >
-                        </template>
-                    </b-table>
-                    <curation-notifications :curation="updatedCuration" class="mt-2"></curation-notifications>
-
-                    <div class="alert alert-info" v-show="message">{{message}}</div>
-                </div>
-
-        </div>
-        <div class="row">
-            <div class="col-lg-8">
-                <div class="form-group" v-if="showRationale">
-                    <label for="rationale_id">What is your rationale for this curation?</label>
-                    <select v-model="updatedCuration.rationales" 
-                        multiple class="form-control" 
-                        style="height: 8.5em"
-                    >
-                        <option v-for="rationale in rationales" :key="rationale.id"
-                            :value="rationale"
-                        >
-                            {{ rationale.name }}
-                        </option>
-                    </select>
-                    <validation-error :messages="errors.rationales"></validation-error>
-                </div>
-                <transition name="fade">
-                    <div class="form-group" v-show="updatedCuration.rationale_id == 100">
-                        <textarea v-model="updatedCuration.rationale_other" placeholder="Other rationale details" class="form-control"></textarea>
-                        <validation-error :messages="errors.rationale_other"></validation-error>
-                    </div>
-                </transition>
-                <div class="form-group" v-show="updatedCuration.curation_type_id != 3">
-                    <label for="pmids">Supporting PMIDS:</label>
-                    <small>comma separated list</small>
-                    <input id="pmids" v-model="updatedCuration.pmids" class="form-control" placeholder="18183754, 123451, 1231231">
-                    <validation-error :messages="errors.pmids"></validation-error>
-                </div>
-                <div class="form-group" v-show="updatedCuration.curation_type_id == 3">
-                    <label for="isolated_phenotype">Enter broader OMIM phenotype (MIM phenotype):</label>
-                    <input id="isolated_phenotype" v-model="updatedCuration.isolated_phenotype" class="form-control">
-                    <validation-error :messages="errors.isolated_phenotype"></validation-error>
-                </div>
-                <div class="form-group">
-                    <label for="rationale_notes">Provide your Rationale:</label>
-                    <textarea id="rationale_notes" v-model="updatedCuration.rationale_notes" class="form-control"></textarea>
-                    <validation-error :messages="errors.rationale_notes"></validation-error>
-                </div>
-            </div>
-            <div class="col-lg-4" v-show="showTable">
-                <criteria-table></criteria-table>
-            </div>
-        </div>
-    </div>
-</template>
 <script>
     import { mapGetters } from 'vuex'
     import curationFormMixin from '../../../mixins/curation_form_mixin'
@@ -142,8 +58,19 @@
                 if (to.gene_symbol != from.gene_symbol) {
                     this.fetchPhenotypes(this.updatedCuration.id)
                         .then((response) => {
-                            if (this.phenotypes?.length == 1 && this.updatedCuration.curation_type_id == 1 && this.updatedCuration?.phenotypes?.length == 0) {
-                                Vue.set( this.updatedCuration.phenotypes, 0, { 'mim_number': this.phenotypes[0].phenotypeMimNumber, 'name': this.phenotypes[0].phenotype });
+                            if (
+                                this.phenotypes?.length === 1 
+                                && this.updatedCuration?.curation_type_id === 1 
+                                && this.updatedCuration?.phenotypes?.length === 0
+                            ) {
+                                Vue.set( 
+                                    this.updatedCuration.phenotypes, 
+                                    0, 
+                                    { 
+                                        'mim_number': this.phenotypes[0].phenotypeMimNumber, 
+                                        'name': this.phenotypes[0].phenotype 
+                                    }
+                                );
                                 this.message = 'We have preselected the phenotype because you indicated you are curating '+this.updatedCuration.gene_symbol+' with this single disease entity';
                             }
 
@@ -171,3 +98,84 @@
         }
     }
 </script>
+<template>
+    <div class="component-container">
+        <div>
+            <div class="alert alert-info" v-show="loading && phenotypes.length < 1">Loading phenotype information...</div>
+            <div  v-show="!loading || phenotypes.length > 0">
+                <div class="alert alert-secondary clearfix" v-show="phenotypes.length == 0">
+                    <p>The gene <strong>{{ updatedCuration.value }}</strong> is not associated with a disease entity per OMIM at this time.</p>
+                </div>
+
+                <b-table 
+                        v-show="showTable"
+                    :items="phenotypes"
+                    :fields="fields"
+                    stacked="sm"
+                    striped 
+                    hover 
+                    small
+                >
+                    <template v-slot:head(checkbox)="data">
+                        &nbsp;&nbsp;&nbsp;&nbsp;
+                    </template>
+                    <template v-slot:cell(checkbox)="data">
+                        <input 
+                            class="form-check-input form-check-input-lg"
+                            type="checkbox" 
+                            v-model="updatedCuration.phenotypes"
+                            :value="data.value"
+                            :disabled="disabled"
+                        >
+                    </template>
+                </b-table>
+                <curation-notifications :curation="updatedCuration" class="mt-2"></curation-notifications>
+
+                <div class="alert alert-info" v-show="message">{{message}}</div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-8">
+                <div class="form-group" v-if="showRationale">
+                    <label for="rationale_id">What is your rationale for this curation?</label>
+                    <select v-model="updatedCuration.rationales" 
+                        multiple class="form-control" 
+                        style="height: 8.5em"
+                    >
+                        <option v-for="rationale in rationales" :key="rationale.id"
+                            :value="rationale"
+                        >
+                            {{ rationale.name }}
+                        </option>
+                    </select>
+                    <validation-error :messages="errors.rationales"></validation-error>
+                </div>
+                <transition name="fade">
+                    <div class="form-group" v-show="updatedCuration.rationale_id == 100">
+                        <textarea v-model="updatedCuration.rationale_other" placeholder="Other rationale details" class="form-control"></textarea>
+                        <validation-error :messages="errors.rationale_other"></validation-error>
+                    </div>
+                </transition>
+                <div class="form-group" v-show="updatedCuration.curation_type_id != 3">
+                    <label for="pmids">Supporting PMIDS:</label>
+                    <small>comma separated list</small>
+                    <input id="pmids" v-model="updatedCuration.pmids" class="form-control" placeholder="18183754, 123451, 1231231">
+                    <validation-error :messages="errors.pmids"></validation-error>
+                </div>
+                <div class="form-group" v-show="updatedCuration.curation_type_id == 3">
+                    <label for="isolated_phenotype">Enter broader OMIM phenotype (MIM phenotype):</label>
+                    <input id="isolated_phenotype" v-model="updatedCuration.isolated_phenotype" class="form-control">
+                    <validation-error :messages="errors.isolated_phenotype"></validation-error>
+                </div>
+                <div class="form-group">
+                    <label for="rationale_notes">Provide your Rationale:</label>
+                    <textarea id="rationale_notes" v-model="updatedCuration.rationale_notes" class="form-control"></textarea>
+                    <validation-error :messages="errors.rationale_notes"></validation-error>
+                </div>
+            </div>
+            <div class="col-lg-4" v-show="showTable">
+                <criteria-table></criteria-table>
+            </div>
+        </div>
+    </div>
+</template>

--- a/tests/Feature/BulkCurationUploadTest.php
+++ b/tests/Feature/BulkCurationUploadTest.php
@@ -16,6 +16,7 @@ class BulkCurationUploadTest extends TestCase
 {
     use DatabaseTransactions;
     protected $fakeCurationSavedEvent = false;
+    private $user, $expertPanel;
 
     public function setUp(): void
     {

--- a/tests/Feature/Notifications/Disease/MondoTermObsoletedNotificationTest.php
+++ b/tests/Feature/Notifications/Disease/MondoTermObsoletedNotificationTest.php
@@ -21,6 +21,8 @@ class MondoTermObsoletedNotificationTest extends TestCase
     use DatabaseTransactions;
     use SetsUpDiseaseWithCuration;
 
+    private $curation, $user1, $disease;
+
     public function setup():void
     {
         parent::setup();

--- a/tests/Unit/BulkCurationProcessorTest.php
+++ b/tests/Unit/BulkCurationProcessorTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use Mockery;
 use App\User;
 use App\Curation;
+use App\Phenotype;
 use Tests\TestCase;
 use App\ExpertPanel;
 use App\Clients\OmimClient;
@@ -22,6 +23,7 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 class BulkCurationProcessorTest extends TestCase
 {
     use DatabaseTransactions;
+    private $user, $ep, $data, $phenotype;
 
     public function setUp(): void
     {
@@ -31,10 +33,7 @@ class BulkCurationProcessorTest extends TestCase
             $this->user = factory(User::class)->create(['email' => 'sirs@unc.edu']);
         }
         $this->ep = factory(ExpertPanel::class)->create([]);
-
-        // $omimClientMock = $this->createMock(OmimClient::class);
-        // $omimClientMock->method('geneSymbolIsValid')->willReturn(true);
-        // $omimClientMock->method('getEntry')->willReturn(true);
+        $this->phenotype = factory(Phenotype::class)->create(['mim_number' => 605724]);
 
         app()->instance(OmimClient::class, new class extends OmimClient {
             public function geneSymbolisValid($symbol) 

--- a/tests/Unit/Http/Controllers/Api/CurationControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/CurationControllerTest.php
@@ -24,6 +24,8 @@ class CurationControllerTest extends TestCase
 {
     use DatabaseTransactions;
 
+    private $user, $curations, $panel, $rationale, $curationType;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -51,21 +53,6 @@ class CurationControllerTest extends TestCase
             ->json('GET', '/api/curations')
              ->assertStatus(200);
     }
-
-    // /**
-    //  * @test
-    //  */
-    // public function index_lists_curations_filtered_by_gene_symbol()
-    // {
-    //     $this->withoutExceptionHandling();
-    //     $testGene = 'BRCA1';
-    //     $curation = factory(\App\Curation::class, 16)->create(['gene_symbol'=>$testGene]);
-
-    //     $response = $this->actingAs($this->user, 'api')
-    //         ->json('GET', '/api/curations?gene_symbol='.$testGene);
-
-    //     $this->assertEquals(16, $response->original->count());
-    // }
 
     /**
      * @test
@@ -236,38 +223,26 @@ class CurationControllerTest extends TestCase
 
     /**
      * @test
+     * @group phenotypes
      */
     public function store_saves_phenotypes_for_new_curation()
     {
-        $phenotype = factory(\App\Phenotype::class)->create();
+        $phenotypes = factory(\App\Phenotype::class, 3)->create();
         $curator = factory(\App\User::class)->create();
 
         $data = [
             'gene_symbol' => 'BRCA1',
             'expert_panel_id' => $this->panel->id,
             'curator_id' => $curator->id,
-            'phenotypes' => [
-                [
-                    'mim_number' => 12345,
-                    'name' => 'test pheno1',
-                ],
-                [
-                    'mim_number' => 67890,
-                    'name' => 'test pheno2',
-                ],
-                [
-                    'mim_number' => $phenotype->mim_number,
-                    'name' => $phenotype->name,
-                ],
-            ],
+            'phenotypes' => $phenotypes->pluck('id'),
             'nav' => 'next',
         ];
 
         $this->actingAs($this->user, 'api')
             ->json('POST', '/api/curations', $data)
-            ->assertJsonFragment(['mim_number'=>$phenotype->mim_number])
-            ->assertJsonFragment(['mim_number'=>12345])
-            ->assertJsonFragment(['mim_number'=>67890])
+            ->assertJsonFragment(['mim_number'=>$phenotypes[0]->mim_number])
+            ->assertJsonFragment(['mim_number'=>$phenotypes[1]->mim_number])
+            ->assertJsonFragment(['mim_number'=>$phenotypes[2]->mim_number])
             ;
     }
 

--- a/tests/Unit/Http/Controllers/Api/CurationControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/CurationControllerTest.php
@@ -54,6 +54,22 @@ class CurationControllerTest extends TestCase
              ->assertStatus(200);
     }
 
+    // /**
+    //  * @test
+    //  */
+    // public function index_lists_curations_filtered_by_gene_symbol()
+    // {
+    //     $this->withoutExceptionHandling();
+    //     $testGene = 'BRCA1';
+    //     $curation = factory(\App\Curation::class, 16)->create(['gene_symbol'=>$testGene]);
+
+    //     $response = $this->actingAs($this->user, 'api')
+    //         ->json('GET', '/api/curations?gene_symbol='.$testGene);
+
+    //     $this->assertEquals(16, $response->original->count());
+    // }
+
+ 
     /**
      * @test
      */

--- a/tests/Unit/Http/Controllers/Api/OmimControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/OmimControllerTest.php
@@ -15,10 +15,13 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 class OmimControllerTest extends TestCase
 {
     use DatabaseTransactions;
+
+    private $user;
+
     public function setUp(): void
     {
         parent::setUp();
-        $this->u = factory(\App\User::class)->create();
+        $this->user = factory(\App\User::class)->create();
     }
     /**
      * @test
@@ -27,7 +30,7 @@ class OmimControllerTest extends TestCase
     {
         $omimEntryResponse = json_decode(file_get_contents(base_path('tests/files/omim_api/entry_response.json')));
         $entry = new OmimEntry($omimEntryResponse->omim->entryList[0]->entry);
-        $response = $this->actingAs($this->u, 'api')
+        $response = $this->actingAs($this->user, 'api')
             ->call('GET', '/api/omim/entry?mim_number=100100');
         $response->assertJson($entry->toArray());
     }
@@ -38,7 +41,7 @@ class OmimControllerTest extends TestCase
     public function searches_omim_entries()
     {
         $omimEntryResponse = json_decode(file_get_contents(base_path('tests/files/omim_api/search_response.json')), true);
-        $this->actingAs($this->u, 'api')
+        $this->actingAs($this->user, 'api')
             ->call('GET', '/api/omim/search?search=myl2')
             ->assertJsonFragment($omimEntryResponse['omim']['searchResponse']['entryList'][0]['entry'])
             ->assertJsonFragment($omimEntryResponse['omim']['searchResponse']['entryList'][1]['entry'])
@@ -53,12 +56,12 @@ class OmimControllerTest extends TestCase
      */
     public function checks_to_see_if_gene_symbol_is_valid()
     {
-        $this->actingAs($this->u, 'api')
+        $this->actingAs($this->user, 'api')
             ->call('GET', '/api/omim/gene/MLTN1')
             ->assertStatus(404)
             ->assertSee('No HGNC gene symbol was found for MLTN1');
 
-        $this->actingAs($this->u, 'api')
+        $this->actingAs($this->user, 'api')
             ->call('GET', '/api/omim/gene/BRCA1')
             ->assertStatus(200);
     }

--- a/tests/Unit/Jobs/Curations/SyncPhenotypesTest.php
+++ b/tests/Unit/Jobs/Curations/SyncPhenotypesTest.php
@@ -11,17 +11,16 @@ class SyncPhenotypesTest extends TestCase
 {
     use DatabaseTransactions;
 
+    private $phs, $curation;
+
     public function setUp(): void
     {
         parent::setUp();
         $this->phs = factory(Phenotype::class, 3)
                         ->create()
-                        ->transform(function ($item) {
-                            return [
-                                'mim_number' => $item->mim_number,
-                                'name' => $item->name
-                            ];
-                        });
+                        ->map(function ($item) {
+                            return $item->mim_number;
+                        })->toArray();
         $this->curation = factory(\App\Curation::class)->create();
     }
 
@@ -43,23 +42,19 @@ class SyncPhenotypesTest extends TestCase
      */
     public function creates_new_phenotypes_and_adds_to_curation()
     {
-        $newMims = collect([
-            [
-                'mim_number' => 123456,
-                'name' => 'transsubstantiation'
-            ],
-            [
-                'mim_number' => 768910,
-                'name' => 'tetrisitis'
-            ]
-        ]);
-        $phs = $this->phs->toBase()->merge($newMims);
+        
+        $newMims = [
+            factory(Phenotype::class)->create(['mim_number' => 123456])->mim_number,
+            factory(Phenotype::class)->create(['mim_number' => 768910])->mim_number,
+        ];
+        $phs = array_merge($this->phs, $newMims);
+
         $job = new SyncPhenotypes($this->curation, $phs);
         $job->handle();
 
         $this->assertEquals(5, $this->curation->phenotypes()->count());
-        $this->assertDatabaseHas('phenotypes', ['mim_number' => 123456, 'name' => 'transsubstantiation']);
-        $this->assertDatabaseHas('phenotypes', ['mim_number' => 768910, 'name' => 'tetrisitis']);
+        $this->assertDatabaseHas('phenotypes', ['mim_number' => 123456]);
+        $this->assertDatabaseHas('phenotypes', ['mim_number' => 768910]);
     }
 
     /**
@@ -70,26 +65,10 @@ class SyncPhenotypesTest extends TestCase
         $job = new SyncPhenotypes($this->curation, $this->phs);
         $job->handle();
 
-        $this->phs->pop();
+        array_pop($this->phs);
         $job = new SyncPhenotypes($this->curation, $this->phs);
         $job->handle();
 
         $this->assertEquals(2, $this->curation->phenotypes()->count());
-    }
-
-    /**
-     * @test
-     */
-    public function allows_multiple_phenotypes_with_the_same_mim_number_with_different_names()
-    {
-        $newPheno = $this->phs->first();
-        $newPheno['name'] = "Bob\'s yer uncle";
-
-        $this->phs->push($newPheno);
-
-        $job = new SyncPhenotypes($this->curation, $this->phs);
-        $job->handle();
-
-        $this->assertEquals(4, $this->curation->phenotypes()->count());
     }
 }


### PR DESCRIPTION
Updates UI and backend to set curation phenotypes by id instead of mim_number/name.