### PR TITLE
Add DOID ID to disease for SCVCEPs in GPM 

### DIFF
--- a/app/Console/Commands/Mondo/UpdateMondoData.php
+++ b/app/Console/Commands/Mondo/UpdateMondoData.php
@@ -4,8 +4,8 @@ namespace App\Console\Commands\Mondo;
 
 use App\Disease;
 use App\AppState;
-use App\Mondo\OboParser;
 use Carbon\Carbon;
+use App\Mondo\OboParser;
 use GuzzleHttp\Psr7\Utils;
 use GuzzleHttp\ClientInterface;
 use Illuminate\Console\Command;

--- a/app/Disease.php
+++ b/app/Disease.php
@@ -12,6 +12,7 @@ class Disease extends Model
 {
     protected $fillable = [
         'mondo_id',
+        'doid_id',
         'name',
         'is_obsolete',
         'replaced_by'
@@ -70,12 +71,11 @@ class Disease extends Model
         return $query->where('mondo_id', $mondoId);
     }
 
-    
     static public function findByMondoId($mondoId)
     {
         return static::mondoId($mondoId)->first();
     }
-    
+
     static public function findByMondoIdOrFail($mondoId)
     {
         return static::mondoId($mondoId)->firstOrFail();

--- a/app/Mondo/OboParser.php
+++ b/app/Mondo/OboParser.php
@@ -48,13 +48,16 @@ class OboParser
             }
 
             if ($inTerm) {
+                if ($line == '[Term]') {
+                    throw new RuntimeException('Poorly-formed OBO file: [Term] block should not be nested');
+                }
                 if ($line == '') {
                     break;
                 }
                 [$key, $val] = explode(": ", $line);
                 
                 // DOID is the only xref we care about and the value requires processing to get only what we want.
-                if ($key == 'xref' && substr($val, 0, 5) == 'DOID:') {
+                if ($key == 'xref' && substr($val, 0, 5) == 'DOID:' && str_contains($val, 'source="MONDO:equivalentTo"')) {
                     $parts = explode(' ', $val);
                     $term['doid_id'] = $parts[0];
                 }

--- a/app/Mondo/OboParser.php
+++ b/app/Mondo/OboParser.php
@@ -8,7 +8,7 @@ class OboParser
         'id' => 'mondo_id',
         'name' => 'name',
         'is_obsolete' => 'is_obsolete',
-        'replaced_by' => 'replaced_by'
+        'replaced_by' => 'replaced_by',
     ];
 
     protected $oboPath;
@@ -52,6 +52,13 @@ class OboParser
                     break;
                 }
                 [$key, $val] = explode(": ", $line);
+                
+                // DOID is the only xref we care about and the value requires processing to get only what we want.
+                if ($key == 'xref' && substr($val, 0, 5) == 'DOID:') {
+                    $parts = explode(' ', $val);
+                    $term['doid_id'] = $parts[0];
+                }
+
                 if (in_array($key, array_keys(static::ATTRS))) {
                     $term[static::ATTRS[$key]] = $this->evaluate($val);
                 }

--- a/database/migrations/2024_12_29_205055_add_doid_id_to_diseases.php
+++ b/database/migrations/2024_12_29_205055_add_doid_id_to_diseases.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('diseases', function (Blueprint $table) {
+            $table->string('doid_id')->nullable()->after('mondo_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('diseases', function (Blueprint $table) {
+            $table->dropColumn('doid_id');
+        });
+    }
+};

--- a/tests/Unit/Mondo/OboParserTest.php
+++ b/tests/Unit/Mondo/OboParserTest.php
@@ -54,6 +54,13 @@ class OboParserTest extends TestCase
             'replaced_by' => 'MONDO:0009299'
         ];
 
+        $testTerm4 = [
+            'mondo_id' => 'MONDO:0000224',
+            'name' => 'acquired carbohydrate metabolism disease',
+            'is_obsolete' => false,
+            'replaced_by' => null,
+        ];
+
         $term1 = $this->parser->getNextTerm();
         $this->assertEquals($testTerm1, $term1);
 
@@ -62,5 +69,8 @@ class OboParserTest extends TestCase
 
         $term3 = $this->parser->getNextTerm();
         $this->assertEquals($testTerm3, $term3);
+
+        $term4 = $this->parser->getNextTerm();
+        $this->assertEquals($testTerm4, $term4);
     }
 }

--- a/tests/Unit/Mondo/OboParserTest.php
+++ b/tests/Unit/Mondo/OboParserTest.php
@@ -10,6 +10,8 @@ use App\Mondo\OboParser;
  */
 class OboParserTest extends TestCase
 {
+    protected $parser;
+    
     public function setup():void
     {
         parent::setup();
@@ -32,6 +34,7 @@ class OboParserTest extends TestCase
     {
         $testTerm1 = [
             'mondo_id' => 'MONDO:0000001',
+            'doid_id' => 'DOID:4',
             'name' => 'disease or disorder',
             "is_obsolete" => false,
             "replaced_by" => null

--- a/tests/files/mondo/mondo_test.obo
+++ b/tests/files/mondo/mondo_test.obo
@@ -105,6 +105,21 @@ is_obsolete: true
 replaced_by: MONDO:0009299
 
 [Term]
+id: MONDO:0000224
+name: acquired carbohydrate metabolism disease
+def: "An acquired metabolic disease that is has its basis in the disruption of carbohydrate metabolism." [https://orcid.org/0000-0002-6601-2165]
+comment: Reason of obsoletion: out of scope - MONDO:excludeHistoricalDisease. Term to consider: -
+subset: obsoletion_candidate
+synonym: "carbohydrate metabolism disease" RELATED [DOID:0050013]
+xref: DOID:0050013 {source="MONDO:equivalentObsolete"}
+is_a: MONDO:0006504 ! acquired metabolic disease
+is_a: MONDO:0037792 ! carbohydrate metabolism disease
+intersection_of: MONDO:0006504 ! acquired metabolic disease
+intersection_of: disease_has_basis_in_disruption_of GO:0005975 ! carbohydrate metabolic process
+property_value: IAO:0000233 "https://github.com/monarch-initiative/mondo/issues/7700" xsd:anyURI
+property_value: IAO:0006012 "2024-09-01" xsd:string
+
+[Term]
 id: MONDO:0000003
 name: obsolete 17-hydroxysteroid dehydrogenase deficiency
 xref: DC:0000002 {source="MONDO:obsoleteEquivalent"}


### PR DESCRIPTION
SC-VCEPS want to use DOID IDs to identify diseases in the GPM. The GPM depends on the GT's snapshot of MonDO to look up diseases.  This PR adds `doid_id` to the `Disease` model and updates the `OboParser` to get them from mondo terms in the OBO file.

See https://github.com/clingen-data-model/gpm/pull/101 for the GPM PR that depends on this change.